### PR TITLE
Buildkite: AWS CI stack update (v5.3.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ node_modules/
 .bundle/
 *.bak
 extra_tags.json
-*.un~

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PACKER_WINDOWS_FILES = $(exec find packer/windows)
 AWS_REGION ?= us-east-1
 
 ARM64_INSTANCE_TYPE = m6g.xlarge
-AMD64_INSTANCE_TYPE = c5.xlarge
+AMD64_INSTANCE_TYPE = c5a.large
 
 all: packer build
 

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -5,25 +5,30 @@
     "goarch": "amd64",
     "instance_type": "m5.xlarge"
   },
-
   "builders": [
     {
       "type": "amazon-ebs",
       "region": "{{user `region`}}",
+      "vpc_id": "vpc-90812ff4",
+      "subnet_id": "subnet-d1dca68a",
       "source_ami_filter": {
         "filters": {
           "name": "amzn2-ami-hvm-2.0.*-gp2",
           "architecture": "{{user `arch`}}",
           "virtualization-type": "hvm"
         },
-        "owners": ["amazon"],
+        "owners": [
+          "amazon"
+        ],
         "most_recent": true
       },
       "instance_type": "{{user `instance_type`}}",
       "ssh_username": "ec2-user",
       "ami_name": "buildkite-stack-linux-{{user `arch`}}-{{isotime | clean_resource_name}}",
       "ami_description": "Buildkite Elastic Stack (Amazon Linux 2 LTS w/ docker)",
-      "ami_groups": ["all"]
+      "ami_groups": [
+        "all"
+      ]
     }
   ],
   "provisioners": [
@@ -72,10 +77,13 @@
     },
     {
       "type": "shell",
+      "script": "scripts/install-solvebio.sh"
+    },
+    {
+      "type": "shell",
       "inline": [
         "rm /home/ec2-user/.ssh/authorized_keys"
       ]
     }
   ]
 }
-

--- a/packer/linux/scripts/install-solvebio.sh
+++ b/packer/linux/scripts/install-solvebio.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu -o pipefail
+
+echo "Instaling gcc..."
+sudo yum install -y gcc
+
+echo "Instaling virtualenv (python 2.7) ..."
+sudo pip install virtualenv

--- a/packer/scripts/install-volume.sh
+++ b/packer/scripts/install-volume.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu -o pipefail
-
-echo "Setting up /data mount point..."
-mkdir /data
-echo "/dev/xvdb   /data       ext4    defaults,nofail 0   2" >> /etc/fstab


### PR DESCRIPTION
### Description
Updating Buildkite's Elastic CI Stack to the latest version [v5.3.1](https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v5.3.1). It uses `buildkite-agent v3.27.0` which enables support for `buildkite-plugins`.

### Motivation
New Elastic CI stack now uses [Amazon Linux 2 LTS](https://aws.amazon.com/amazon-linux-2/). It doesn't have some tools already preinstalled like the older linux distribution used for previous verion of Buildkite's Elastic CI Stack. Because of that we needed to create our custom AMI [ami-0189f4cad31f46720](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Images:sort=imageId), which preinstalls tools needed for for our deployment scripts (`python 2.7 virtualenv` and `gcc` compiler for installing python `pycrypto` library).

### Changes
- Added additional building steps: `packer/linux/install-solvebio.sh` script
- Updated `packer/linux/buildkite-ami.json` with new script and `default AWS VPC and subnet` (note: subnet needs to have a public IP address in order to build AMI).  
- Deleting our old changes (for moutning a volume)

### Update steps
1. `git submodule update --init --recursive`
2. `make build` (note: aws credentials and solvebio-dev profile must be configured ) -  builds AMI and if successful you should see it in AWS console.
3. Update `CloudFormation` for buildkite (`buildkite-v2`) with the target Elastic CI Stack CloudFormation yaml file. You can see the links for the new stacks in the [buildkite release notes](https://github.com/buildkite/elastic-ci-stack-for-aws/releases). 
4. In one of the steps during CloudFormation update, set the value for AMI Image ID: `ImageId
Optional - Custom AMI to use for instances (must be based on the stack's AMI)`

### Note: update improvement
Building custom AMI with packer can be avoided with using bootstrap script that is executed on instance boot: [example](https://github.com/buildkite/elastic-ci-stack-for-aws#customizing-instances-with-a-bootstrap-script).

Example in [SolveOps](https://github.com/solvebio/solveops/blob/master/solveops/buildkite/bootstrap.sh) 
